### PR TITLE
feature yen

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,9 @@ curl "https://decodeco.vercel.app/api/v1/decode?target=\xe3\x81\xa7\xe3\x81\x93"
 npm install -g http-server
 /usr/local/lib/node_modules/http-server/bin/http-server -p 5000
 #=> http://localhost:5000/
+
+# test
+echo '{ "type": "module" }' > package.json
+node --experimental-modules ./src/test.js
 ```
+

--- a/src/decodeco.js
+++ b/src/decodeco.js
@@ -7,19 +7,18 @@ function decodeUTF8(encoded_string) {
 }
 
 export function decodeco(string) {
-  let result = '';
-
-  // UTF-8 decode
-  try {
-    result = decodeUTF8(string);
-  } catch(error) {
-    // console.error(error);
-  }
+  let result = string;
 
   // URI decode
   try {
     result = decodeURI(result);
-    return result;
+  } catch(error) {
+    // console.error(error);
+  }
+
+  // UTF-8 decode
+  try {
+    result = decodeUTF8(result);
   } catch(error) {
     // console.error(error);
   }
@@ -27,10 +26,10 @@ export function decodeco(string) {
   // Unicode decode
   try {
     result = unescape(result);
-    return result;
   } catch(error) {
     // console.error(error);
   }
 
   return result;
 }
+

--- a/src/test.js
+++ b/src/test.js
@@ -37,6 +37,7 @@ function test() {
     it('  UTF-8のバイト文字列を渡した場合decodeされる', () =>{
       expect('でこ', decodeco("\\xe3\\x81\\xa7\\xe3\\x81\\x93"));
       expect('でこ', decodeco("で\\xe3\\x81\\x93"));
+      expect('でこ', decodeco("で%5Cxe3%5Cx81%5Cx93"));
     });
     // it('  URLエンコード済みの文字列かつ、Unicodeエンコード済みの文字列を渡した場合エラーが発生する', () =>{
     //   expect(original, decodeco(`${encodeURI(original)}${escape(original)}`));
@@ -45,3 +46,4 @@ function test() {
 }
 
 test();
+


### PR DESCRIPTION
## 概要

`\`が`%5C`(¥)の場合のUTF-8のバイト文字列もデコードできるようにしました。